### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-detectable linguist-language=hosts


### PR DESCRIPTION
.gitattributes is a file that can to varying extents add colours to text files, depending on GitHub Linguist. This means that hosts entries can be shown in blue, and comments in grey.

For the occasion of a Linguist update earlier today (Wednesday) that added Hosts support, I decided to write such a file for this repo.

Since all current `.txt` files in the repo at the moment are hosts files, a simple `*.txt` filename match should work out for the time being.
![image](https://github.com/r-a-y/mobile-hosts/assets/22780683/511f5d7c-8681-46ad-bdb6-882da3b1e91a)